### PR TITLE
[LOAN-5698] Update Inflector API

### DIFF
--- a/.php_cs
+++ b/.php_cs
@@ -54,7 +54,7 @@ return \PhpCsFixer\Config::create()
             'no_trailing_comma_in_singleline_array' => true,
             'no_unneeded_control_parentheses' => true,
             'no_unneeded_curly_braces' => true,
-            'no_unneeded_final_method' => true,
+            'no_unneeded_final_method' => false,
             'no_unreachable_default_argument_value' => false,
             'no_unused_imports' => true,
             'no_useless_else' => true,

--- a/composer.json
+++ b/composer.json
@@ -34,7 +34,8 @@
         "doctrine/orm": "~2.1",
         "stof/doctrine-extensions-bundle": "*",
         "symfony/framework-bundle": "^3.4|^4.0",
-        "symfony/security-bundle": "^3.4|^4.0"
+        "symfony/security-bundle": "^3.4|^4.0",
+        "doctrine/inflector": "^1.4"
     },
     "require-dev": {
         "behat/behat": "^3.4",

--- a/composer.json
+++ b/composer.json
@@ -32,10 +32,10 @@
         "ext-json": "*",
         "doctrine/doctrine-bundle": "~1.6",
         "doctrine/orm": "~2.1",
+        "doctrine/inflector": "^1.4",
         "stof/doctrine-extensions-bundle": "*",
         "symfony/framework-bundle": "^3.4|^4.0",
-        "symfony/security-bundle": "^3.4|^4.0",
-        "doctrine/inflector": "^1.4"
+        "symfony/security-bundle": "^3.4|^4.0"
     },
     "require-dev": {
         "behat/behat": "^3.4",

--- a/src/EventListener/VisitorTrackingSubscriber.php
+++ b/src/EventListener/VisitorTrackingSubscriber.php
@@ -167,7 +167,7 @@ class VisitorTrackingSubscriber implements EventSubscriberInterface
         $session->setUserAgent(\is_string($userAgent) ? $userAgent : '');
         $session->setQueryString($request->getQueryString() ?: '');
         $session->setLoanTerm($request->query->get('y') ?: '');
-        $session->setRepApr($request->query->has('r') ? (string) (\hexdec($request->query->get('r')) / 100) : '');
+        $session->setRepApr($request->query->has('r') ? (string) (\hexdec((string) $request->query->get('r')) / 100) : '');
 
         foreach (self::UTM_CODES as $code) {
             $method = 'set'.InflectorFactory::create()->build()->classify($code);

--- a/src/EventListener/VisitorTrackingSubscriber.php
+++ b/src/EventListener/VisitorTrackingSubscriber.php
@@ -8,7 +8,7 @@ use Alpha\VisitorTrackingBundle\Entity\Lifetime;
 use Alpha\VisitorTrackingBundle\Entity\PageView;
 use Alpha\VisitorTrackingBundle\Entity\Session;
 use Alpha\VisitorTrackingBundle\Storage\SessionStore;
-use Doctrine\Common\Inflector\Inflector;
+use Doctrine\Inflector\InflectorFactory;
 use Doctrine\ORM\EntityManager;
 use Symfony\Bundle\SecurityBundle\Security\FirewallMap;
 use Symfony\Component\EventDispatcher\EventSubscriberInterface;
@@ -170,7 +170,7 @@ class VisitorTrackingSubscriber implements EventSubscriberInterface
         $session->setRepApr($request->query->has('r') ? (string) (\hexdec($request->query->get('r')) / 100) : '');
 
         foreach (self::UTM_CODES as $code) {
-            $method = 'set'.Inflector::classify($code);
+            $method = 'set'.InflectorFactory::create()->build()->classify($code);
             $session->$method($request->query->get($code) ?: '');
         }
 
@@ -209,7 +209,7 @@ class VisitorTrackingSubscriber implements EventSubscriberInterface
         }
 
         foreach (self::UTM_CODES as $code) {
-            $method = 'get'.Inflector::classify($code);
+            $method = 'get'.InflectorFactory::create()->build()->classify($code);
 
             if ($request->query->get($code, '') !== $session->$method()) {
                 return false;

--- a/src/Features/Context/DeviceContext.php
+++ b/src/Features/Context/DeviceContext.php
@@ -7,7 +7,7 @@ use Alpha\VisitorTrackingBundle\EventListener\VisitorTrackingSubscriber;
 use Behat\Behat\Context\Context;
 use Behat\Behat\Context\SnippetAcceptingContext;
 use Behat\MinkExtension\Context\RawMinkContext;
-use Doctrine\Common\Inflector\Inflector;
+use Doctrine\Inflector\InflectorFactory;
 use Doctrine\ORM\EntityManagerInterface;
 use Alpha\VisitorTrackingBundle\Entity\Lifetime;
 
@@ -44,7 +44,7 @@ class DeviceContext extends RawMinkContext implements Context, SnippetAcceptingC
         $session->setLoanTerm('');
         $session->setRepApr('');
         foreach ($this->utmCodes as $code) {
-            $method = 'set'.Inflector::classify($code);
+            $method = 'set'.InflectorFactory::create()->build()->classify($code);
             $session->$method('');
         }
 

--- a/tools/phpstan/phpstan.neon
+++ b/tools/phpstan/phpstan.neon
@@ -7,7 +7,7 @@ parameters:
 	checkMissingIterableValueType: false
 	reportUnmatchedIgnoredErrors: false
 	ignoreErrors:
-		- "#Call to function method_exists() with 'Symfony\\\\Component…' and 'getRootNode' will always evaluate to false.#"
+		- "#Call to function method_exists\\(\\) with 'Symfony\\\\Component…' and 'getRootNode' will always evaluate to false.#"
 
 services:
     -


### PR DESCRIPTION
Fix for

>[2020-10-12 12:48:17] [5f84428196ce6] php.INFO: User Deprecated: The "Doctrine\Common\Inflector\Inflector::classify" method is deprecated and will be dropped in doctrine/inflector 2.0. Please update to the new Inflector API. {"exception":"[object] (ErrorException(code: 0): User Deprecated: The \"Doctrine\\Common\\Inflector\\Inflector::classify\" method is deprecated and will be dropped in doctrine/inflector 2.0. Please update to the new Inflector API. at /srv/app/vendor/doctrine/inflector/lib/Doctrine/Common/Inflector/Inflector.php:90)"}

Require "doctrine/inflector": "^1.4" where new API has been introduced.
https://github.com/doctrine/inflector/releases/tag/1.4.0